### PR TITLE
Temporary disable file upload in OpenAI

### DIFF
--- a/sam/slack.py
+++ b/sam/slack.py
@@ -72,7 +72,6 @@ async def handle_message(event: {str, Any}, say: AsyncSay):
             thread_id=thread_id,
             content=text,
             role="user",
-            file_ids=file_ids,
         )
         logger.info(
             f"User={user_id} added Message={client_msg_id} added to Thread={thread_id}"


### PR DESCRIPTION
We need to migrate the logic:
https://platform.openai.com/docs/assistants/migration/what-has-changed

But this takes a bit more time.