### PR TITLE
Use HTML URL for creating GitHub issues

### DIFF
--- a/sam/contrib/github/__init__.py
+++ b/sam/contrib/github/__init__.py
@@ -68,7 +68,7 @@ class GitHubAPIWrapperStub(AbstractGitHubAPIWrapper):
         return {
             "title": title,
             "body": body,
-            "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "html_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         }
 
 

--- a/sam/tools.py
+++ b/sam/tools.py
@@ -176,7 +176,7 @@ def create_github_issue(title: str, body: str) -> str:
             logger.exception("Failed to create issue on GitHub")
             return "failed to create issue"
         else:
-            return response["url"]
+            return response["html_url"]
 
 
 def platform_search(query: str) -> str:


### PR DESCRIPTION
`url` returns the API URL, which is useless for the end user.
