### PR TITLE
Fix #66 -- Handle special subtyptes

### DIFF
--- a/sam/slack.py
+++ b/sam/slack.py
@@ -49,6 +49,9 @@ async def get_bot_user_id():
 async def handle_message(event: {str, Any}, say: AsyncSay):
     """Handle a message event from Slack."""
     logger.debug(f"handle_message={json.dumps(event)}")
+    if event.get("subtype") == "message_deleted":
+        logger.debug("Ignoring message_deleted event %s", event)
+        return  # https://api.slack.com/events/message#hidden_subtypes
     bot_id = await get_bot_user_id()
     channel_id = event["channel"]
     channel_type = event["channel_type"]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 
 import pytest
@@ -66,6 +67,22 @@ async def test_handle_message(monkeypatch):
         file_ids=["file-1"],
         voice_prompt=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_handle_message__subtype_deleted(caplog):
+    event = {
+        "type": "message",
+        "subtype": "message_deleted",
+        "hidden": True,
+        "channel": "C123ABC456",
+        "ts": "1358878755.000001",
+        "deleted_ts": "1358878749.000002",
+        "event_ts": "1358878755.000002",
+    }
+    with caplog.at_level(logging.DEBUG):
+        await slack.handle_message(event, None)
+    assert "Ignoring message_deleted event" in caplog.text
 
 
 def test_get_user_profile(monkeypatch):


### PR DESCRIPTION
See also: https://api.slack.com/events/message#hidden_subtypes
