### PR TITLE
Refs #66 -- handle edited Slack message

### DIFF
--- a/sam/slack.py
+++ b/sam/slack.py
@@ -11,13 +11,13 @@ from typing import Any
 
 import redis.asyncio as redis
 from slack_bolt.async_app import AsyncSay
-from slack_sdk import WebClient, errors
+from slack_sdk import errors
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.web.client import WebClient
 
 import sam.bot
 
-from . import bot, config, utils
+from . import bot, config
 from .utils import logger
 
 logger = logging.getLogger(__name__)
@@ -59,6 +59,9 @@ async def handle_message(event: {str, Any}, say: AsyncSay):
     if event.get("subtype") == "message_deleted":
         logger.debug("Ignoring message_deleted event %s", event)
         return  # https://api.slack.com/events/message#hidden_subtypes
+    if event.get("subtype") == "message_changed":
+        logger.debug("Ignoring message_changed event %s", event)
+        return
     bot_id = await get_bot_user_id()
     channel_id = event["channel"]
     channel_type = event["channel_type"]

--- a/sam/slack.py
+++ b/sam/slack.py
@@ -56,11 +56,8 @@ async def get_bot_user_id():
 async def handle_message(event: {str, Any}, say: AsyncSay):
     """Handle a message event from Slack."""
     logger.debug(f"handle_message={json.dumps(event)}")
-    if event.get("subtype") == "message_deleted":
-        logger.debug("Ignoring message_deleted event %s", event)
-        return  # https://api.slack.com/events/message#hidden_subtypes
-    if event.get("subtype") == "message_changed":
-        logger.debug("Ignoring message_changed event %s", event)
+    if event.get("subtype") in ["message_changed", "message_deleted"]:
+        logger.debug(f"Ignoring `{event['subtype']}` event {event}")
         return
     bot_id = await get_bot_user_id()
     channel_id = event["channel"]

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -82,6 +82,27 @@ async def test_handle_message__subtype_deleted(caplog):
     assert "Ignoring message_deleted event" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_handle_message__subtype_changed(caplog):
+    event = {
+        "type": "message",
+        "subtype": "message_changed",
+        "hidden": True,
+        "channel": "C123ABC456",
+        "ts": "1358878755.000001",
+        "message": {
+            "type": "message",
+            "user": "U123ABC456",
+            "text": "Hello, world!",
+            "ts": "1355517523.000005",
+            "edited": {"user": "U123ABC456", "ts": "1358878755.000001"},
+        },
+    }
+    with caplog.at_level(logging.DEBUG):
+        await slack.handle_message(event, None)
+    assert "Ignoring message_changed event" in caplog.text
+
+
 def test_get_user_profile(monkeypatch):
     client = mock.MagicMock()
     client.users_profile_get.return_value = {

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -79,7 +79,7 @@ async def test_handle_message__subtype_deleted(caplog):
     }
     with caplog.at_level(logging.DEBUG):
         await slack.handle_message(event, None)
-    assert "Ignoring message_deleted event" in caplog.text
+    assert "Ignoring `message_deleted` event" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -100,7 +100,7 @@ async def test_handle_message__subtype_changed(caplog):
     }
     with caplog.at_level(logging.DEBUG):
         await slack.handle_message(event, None)
-    assert "Ignoring message_changed event" in caplog.text
+    assert "Ignoring `message_changed` event" in caplog.text
 
 
 def test_get_user_profile(monkeypatch):


### PR DESCRIPTION
Along with deleting messages, Slack users can edit them.

I would rather not complicate things here and introduce updating logic via OpenAI API. Especially with the fact the most editing of the messages (before AI replies) is happening due to the typos and AI does not care much about the typos.
So, the same thing as for the deleting messages - we just ignore such signals.


## How to test

```bash
sam run slack
```

Send a message to a bot, instantly edit it.
There should be no errors in the logs and the bot should respond with a message, not error emoji.