### PR TITLE
Fix #82 -- Handle bad request errors and feed them back to the user

### DIFF
--- a/sam/bot.py
+++ b/sam/bot.py
@@ -236,15 +236,22 @@ async def add_message(
                 purpose="assistants",
             )
             file_ids.append(new_file.id)
-    await client.beta.threads.messages.create(
-        thread_id=thread_id,
-        content=content,
-        role=Roles.USER,
-        attachments=[
-            {"file_id": file_id, "tools": [{"type": "file_search"}]}
-            for file_id in file_ids
-        ],
-    )
+
+    try:
+        await client.beta.threads.messages.create(
+            thread_id=thread_id,
+            content=content,
+            role=Roles.USER,
+            attachments=[
+                {"file_id": file_id, "tools": [{"type": "file_search"}]}
+                for file_id in file_ids
+            ],
+        )
+    except openai.BadRequestError as e:
+        error = OSError()
+        error.strerror = e.body["message"]
+        raise error
+
     return bool(file_ids), voice_prompt
 
 

--- a/sam/bot.py
+++ b/sam/bot.py
@@ -248,9 +248,7 @@ async def add_message(
             ],
         )
     except openai.BadRequestError as e:
-        error = OSError()
-        error.strerror = e.body["message"]
-        raise error
+        raise OSError("The assistant could not process this message.") from e
 
     return bool(file_ids), voice_prompt
 

--- a/sam/slack.py
+++ b/sam/slack.py
@@ -92,7 +92,7 @@ async def handle_message(event: {str, Any}, say: AsyncSay):
             if channel_type == "im" or event.get("parent_user_id") == bot_id:
                 has_attachments, has_audio = await bot.add_message(
                     thread_id=thread_id,
-                    content=f"Inform the user about: {traceback.format_exc(limit=1)}",
+                    content=f"Briefly inform the user about: {traceback.format_exc(limit=1)} Include links.",
                 )
 
     # we need to release the lock before starting a new run

--- a/sam/slack.py
+++ b/sam/slack.py
@@ -88,7 +88,7 @@ async def handle_message(event: {str, Any}, say: AsyncSay):
             if channel_type == "im":
                 await say(
                     channel=channel_id,
-                    text="I'm sorry, I can't process this. %s" % e.strerror,
+                    text=f"I'm sorry, I can't process this. {e.strerror}",
                 )
             return
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from unittest import mock
 
 import pytest
+from openai import BadRequestError
 from openai.types.beta.threads import (
     ImageFile,
     ImageFileContentBlock,
@@ -74,6 +75,16 @@ async def test_add_message__audio(client):
     assert client.beta.threads.messages.create.call_args == mock.call(
         thread_id="thread-1", content="Hello\nWorld", role="user", attachments=[]
     )
+
+
+@pytest.mark.asyncio
+async def test_add_message__bad_request(client):
+    client.beta.threads.messages.create.side_effect = BadRequestError(
+        response=mock.Mock(), message="Bad request", body={"message": "Bad Request"}
+    )
+    with pytest.raises(OSError) as e:
+        await bot.add_message("thread-1", "", [])
+    assert e.value.strerror == "Bad Request"
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -82,9 +82,8 @@ async def test_add_message__bad_request(client):
     client.beta.threads.messages.create.side_effect = BadRequestError(
         response=mock.Mock(), message="Bad request", body={"message": "Bad Request"}
     )
-    with pytest.raises(OSError) as e:
+    with pytest.raises(OSError):
         await bot.add_message("thread-1", "", [])
-    assert e.value.strerror == "Bad Request"
 
 
 @pytest.mark.asyncio

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -143,7 +143,9 @@ async def test_handle_message__bad_request(caplog, monkeypatch):
     assert add_message.call_count == 2
 
     assert "Hello" in add_message.call_args_list[0][1]["content"]
-    assert "Inform the user about" in add_message.call_args_list[1][1]["content"]
+    content_2 = add_message.call_args_list[1][1]["content"]
+    assert "Briefly inform the user about" in content_2
+    assert "Include links" in content_2
 
 
 def test_get_user_profile(monkeypatch):


### PR DESCRIPTION
<img width="1419" alt="image" src="https://github.com/voiio/Sam/assets/14031765/6a4db075-237c-4207-b5d9-0aeec4767589">

### How to test
- Setup alpha sam
1. Upload a png file in a private chat
2. Upload a pdf file in a private chat and add no message


Open question
- Does currently not work within a group chat. Even if sam is addressed directly. I'm not sure we need this. And if we need it, I'm not sure how to address it.