### PR TITLE
Fix #94 -- Catch database errors more broadly

### DIFF
--- a/sam/contrib/postgres/tools.py
+++ b/sam/contrib/postgres/tools.py
@@ -31,7 +31,7 @@ def fetch_all(query: str, _context=None) -> str:
             cur.execute(
                 f"select jsonb_build_object('data', jsonb_agg(t)) from ({query}) t"  # noqa: S608
             )
-        except psycopg.ProgrammingError as e:
+        except psycopg.DatabaseError as e:
             logger.exception("Error executing query: %s", query)
             return str(e)
 


### PR DESCRIPTION
psycopg.DatabaseError is a common base for all errors that are directly
related to the database.


### How to test
- Try to provoke a wrong SQL statement
  e.g. `give me all blue roses from the database`
- Check the logs for the error and you should get a response
