### PR TITLE
Sanitize funciton arguments which are 'invalid' JSON

### DIFF
--- a/sam/bot.py
+++ b/sam/bot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import datetime
 import json
 import logging
@@ -90,7 +91,9 @@ async def call_tools(run: openai.types.beta.threads.Run, **context) -> None:
                 f"Tool {tool_call.function.name} not found, cancelling run {run.id}"
             ) from e
         try:
-            kwargs = json.loads(tool_call.function.arguments)
+            kwargs = json.loads(
+                json.dumps(ast.literal_eval(tool_call.function.arguments))
+            )
         except json.JSONDecodeError as e:
             await client.beta.threads.runs.cancel(
                 run_id=run.id, thread_id=run.thread_id

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -106,15 +106,15 @@ async def test_call_tools__io_error_fn_name(client):
 
 
 @pytest.mark.asyncio
-async def test_call_tools__io_error_fn_kwargs(client):
+async def test_call_tools__type_error_fn_kwargs(client):
     run = mock.MagicMock()
     tool_call = mock.MagicMock()
     tool_call.function.name = "web_search"
     tool_call.function.arguments = "{'notJSON'}"
     run.required_action.submit_tool_outputs.tool_calls = [tool_call]
-    with pytest.raises(OSError) as e:
+    with pytest.raises(TypeError) as e:
         await bot.call_tools(run)
-    assert "Invalid arguments" in str(e.value)
+    assert "Object of type set is not JSON serializable" in str(e.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
See also: https://community.openai.com/t/response-from-tools-call-function-arguments-is-not-consistently-valid-json/594040/3
