### PR TITLE
Drop removed API attribute `quote` from `FileCitation`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "redis",
   "requests",
   "slack-bolt",
-  "openai==1.33.*",
+  "openai>=1.21.0",
   "pyyaml",
   "algoliasearch",
   "sentry-sdk",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "redis",
   "requests",
   "slack-bolt",
-  "openai>=1.21.0",
+  "openai==1.33.*",
   "pyyaml",
   "algoliasearch",
   "sentry-sdk",

--- a/sam/bot.py
+++ b/sam/bot.py
@@ -207,7 +207,7 @@ async def annotate_citations(
 
         if file_citation := getattr(annotation, "file_citation", None):
             cited_file = await client.files.retrieve(file_citation.file_id)
-            citations.append(f"[{index}] {file_citation.quote} — {cited_file.filename}")
+            citations.append(f"[{index}] {cited_file.filename}")
         elif file_path := getattr(annotation, "file_path", None):
             cited_file = await client.files.retrieve(file_path.file_id)
             citations.append(f"[{index}]({cited_file.filename})")

--- a/sam/bot.py
+++ b/sam/bot.py
@@ -207,7 +207,7 @@ async def annotate_citations(
 
         if file_citation := getattr(annotation, "file_citation", None):
             cited_file = await client.files.retrieve(file_citation.file_id)
-            citations.append(f"[{index}] {cited_file.filename}")
+            citations.append(f"[{index}]({cited_file.filename})")
         elif file_path := getattr(annotation, "file_path", None):
             cited_file = await client.files.retrieve(file_path.file_id)
             citations.append(f"[{index}]({cited_file.filename})")


### PR DESCRIPTION
OpenAI broke their library (>v1.33), it does not reflect their API:
https://github.com/openai/openai-python/issues/1498
This addresses https://voiio.sentry.io/issues/2046357/events/b726ec8de7e14bd896e26d57b88249a5/

Since `quote` is not really needed here, dropping it.