### PR TITLE
Fix Algolia import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "slack-bolt",
   "openai>=1.21.0",
   "pyyaml",
-  "algoliasearch",
+  "algoliasearch>=4.4.0",
   "sentry-sdk",
 ]
 

--- a/sam/contrib/algolia/__init__.py
+++ b/sam/contrib/algolia/__init__.py
@@ -3,7 +3,7 @@
 import abc
 
 import requests
-from algoliasearch.search_client import SearchClient
+from algoliasearch.search.client import SearchClient
 
 from . import config
 


### PR DESCRIPTION
CI breaks on main because of a failing import with an updated algolia version.