### PR TITLE
Allow disabling Redis SSL verification for `rediss` schema

### DIFF
--- a/sam/bot.py
+++ b/sam/bot.py
@@ -8,10 +8,10 @@ from pathlib import Path
 
 import openai
 from openai._types import FileTypes
-from redis import asyncio as redis
 
 from . import config, utils
 from .typing import AUDIO_FORMATS, Roles, RunStatus
+from .utils import async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -287,7 +287,9 @@ async def get_thread_id(slack_id) -> str:
     Returns:
         The thread id.
     """
-    async with redis.from_url(config.REDIS_URL) as redis_client:
+    async with async_redis_client(
+        config.REDIS_URL, config.REDIS_VERIFY_SSL
+    ) as redis_client:
         thread_id = await redis_client.get(slack_id)
         if thread_id:
             thread_id = thread_id.decode()

--- a/sam/bot.py
+++ b/sam/bot.py
@@ -288,7 +288,7 @@ async def get_thread_id(slack_id) -> str:
         The thread id.
     """
     async with async_redis_client(
-        config.REDIS_URL, config.REDIS_VERIFY_SSL
+        config.REDIS_URL, ssl_cert_reqs=config.REDIS_CERT_REQS
     ) as redis_client:
         thread_id = await redis_client.get(slack_id)
         if thread_id:

--- a/sam/bot.py
+++ b/sam/bot.py
@@ -9,9 +9,8 @@ from pathlib import Path
 import openai
 from openai._types import FileTypes
 
-from . import config, utils
+from . import config, redis_utils, utils
 from .typing import AUDIO_FORMATS, Roles, RunStatus
-from .utils import async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -287,9 +286,7 @@ async def get_thread_id(slack_id) -> str:
     Returns:
         The thread id.
     """
-    async with async_redis_client(
-        config.REDIS_URL, ssl_cert_reqs=config.REDIS_CERT_REQS
-    ) as redis_client:
+    async with redis_utils.async_redis_client(config.REDIS_URL) as redis_client:
         thread_id = await redis_client.get(slack_id)
         if thread_id:
             thread_id = thread_id.decode()

--- a/sam/config.py
+++ b/sam/config.py
@@ -19,6 +19,7 @@ _TRUTHY = {"1", "true", "yes", "on"}
 # General
 #: The URL of the Redis database server.
 REDIS_URL: str = os.getenv("REDIS_URL", "redis:///")
+REDIS_VERIFY_SSL: bool = os.getenv("REDIS_VERIFY_SSL", "true").lower() in _TRUTHY
 #: How often the bot randomly responds in a group channel.
 RANDOM_RUN_RATIO: float = float(os.getenv("RANDOM_RUN_RATIO", "0"))
 #: The timezone the bot "lives" in.

--- a/sam/config.py
+++ b/sam/config.py
@@ -19,7 +19,7 @@ _TRUTHY = {"1", "true", "yes", "on"}
 # General
 #: The URL of the Redis database server.
 REDIS_URL: str = os.getenv("REDIS_URL", "redis:///")
-REDIS_VERIFY_SSL: bool = os.getenv("REDIS_VERIFY_SSL", "true").lower() in _TRUTHY
+REDIS_CERT_REQS: str = os.getenv("REDIS_CERT_REQS", "required")
 #: How often the bot randomly responds in a group channel.
 RANDOM_RUN_RATIO: float = float(os.getenv("RANDOM_RUN_RATIO", "0"))
 #: The timezone the bot "lives" in.

--- a/sam/redis_utils.py
+++ b/sam/redis_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import contextlib
+
+import redis.asyncio as redis
+from redis.asyncio.connection import parse_url
+
+from sam import config
+
+
+@contextlib.asynccontextmanager
+async def async_redis_client(url):
+    """Asynchronous context manager to get a Redis client."""
+    connection_config = parse_url(url)
+    if connection_config.get("connection_class") == redis.SSLConnection:
+        connection_config["ssl_cert_reqs"] = config.REDIS_CERT_REQS
+
+    client = await redis.Redis(**connection_config)
+    try:
+        yield client
+    finally:
+        await client.aclose()

--- a/sam/slack.py
+++ b/sam/slack.py
@@ -75,7 +75,9 @@ async def handle_message(event: {str, Any}, say: AsyncSay):
             files.append((file["name"], response.read()))
 
     async with (
-        async_redis_client(config.REDIS_URL, config.REDIS_VERIFY_SSL) as redis_client,
+        async_redis_client(
+            config.REDIS_URL, ssl_cert_reqs=config.REDIS_CERT_REQS
+        ) as redis_client,
         redis_client.lock(thread_id, timeout=10 * 60, thread_local=False),
     ):  # 10 minutes
         try:
@@ -150,7 +152,9 @@ async def send_response(
 
     # We may wait for the messages being processed, before starting a new run
     async with (
-        async_redis_client(config.REDIS_URL, config.REDIS_VERIFY_SSL) as redis_client,
+        async_redis_client(
+            config.REDIS_URL, ssl_cert_reqs=config.REDIS_CERT_REQS
+        ) as redis_client,
         redis_client.lock(thread_id, timeout=10 * 60),
     ):  # 10 minutes
         logger.info("User=%s starting run for Thread=%s", user_id, thread_id)

--- a/sam/slack.py
+++ b/sam/slack.py
@@ -10,7 +10,6 @@ import urllib.request
 from datetime import datetime
 from typing import Any
 
-import redis.asyncio as redis
 from slack_bolt.async_app import AsyncSay
 from slack_sdk import errors
 from slack_sdk.web.async_client import AsyncWebClient
@@ -19,6 +18,7 @@ from slack_sdk.web.client import WebClient
 import sam.bot
 
 from . import bot, config
+from .utils import async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ async def handle_message(event: {str, Any}, say: AsyncSay):
             files.append((file["name"], response.read()))
 
     async with (
-        redis.from_url(config.REDIS_URL) as redis_client,
+        async_redis_client(config.REDIS_URL, config.REDIS_VERIFY_SSL) as redis_client,
         redis_client.lock(thread_id, timeout=10 * 60, thread_local=False),
     ):  # 10 minutes
         try:
@@ -150,7 +150,7 @@ async def send_response(
 
     # We may wait for the messages being processed, before starting a new run
     async with (
-        redis.from_url(config.REDIS_URL) as redis_client,
+        async_redis_client(config.REDIS_URL, config.REDIS_VERIFY_SSL) as redis_client,
         redis_client.lock(thread_id, timeout=10 * 60),
     ):  # 10 minutes
         logger.info("User=%s starting run for Thread=%s", user_id, thread_id)

--- a/sam/slack.py
+++ b/sam/slack.py
@@ -17,8 +17,7 @@ from slack_sdk.web.client import WebClient
 
 import sam.bot
 
-from . import bot, config
-from .utils import async_redis_client
+from . import bot, config, redis_utils
 
 logger = logging.getLogger(__name__)
 
@@ -75,9 +74,7 @@ async def handle_message(event: {str, Any}, say: AsyncSay):
             files.append((file["name"], response.read()))
 
     async with (
-        async_redis_client(
-            config.REDIS_URL, ssl_cert_reqs=config.REDIS_CERT_REQS
-        ) as redis_client,
+        redis_utils.async_redis_client(config.REDIS_URL) as redis_client,
         redis_client.lock(thread_id, timeout=10 * 60, thread_local=False),
     ):  # 10 minutes
         try:
@@ -152,9 +149,7 @@ async def send_response(
 
     # We may wait for the messages being processed, before starting a new run
     async with (
-        async_redis_client(
-            config.REDIS_URL, ssl_cert_reqs=config.REDIS_CERT_REQS
-        ) as redis_client,
+        redis_utils.async_redis_client(config.REDIS_URL) as redis_client,
         redis_client.lock(thread_id, timeout=10 * 60),
     ):  # 10 minutes
         logger.info("User=%s starting run for Thread=%s", user_id, thread_id)

--- a/sam/utils.py
+++ b/sam/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import enum
 import importlib
 import inspect
@@ -12,12 +11,11 @@ from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
 
-import redis.asyncio as redis
 import yaml
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["func_to_tool", "async_redis_client"]
+__all__ = ["func_to_tool"]
 
 
 type_map = {
@@ -130,16 +128,3 @@ class Tool:
 
     def __call__(self, *args, **kwargs):
         return self.fn(*args, **kwargs)
-
-
-@contextlib.asynccontextmanager
-async def async_redis_client(url, ssl_cert_reqs="required"):
-    """Asynchronous context manager to get a Redis client."""
-    if url.startswith("rediss://"):
-        client = await redis.from_url(url, ssl_cert_reqs=ssl_cert_reqs)
-    else:
-        client = await redis.from_url(url)
-    try:
-        yield client
-    finally:
-        await client.aclose()

--- a/sam/utils.py
+++ b/sam/utils.py
@@ -155,18 +155,18 @@ async def async_redis_client(url, verify_ssl=True):
             await client.set("key", "value")
     """
     is_ssl_connection = url.startswith("rediss://")
-    if not is_ssl_connection or verify_ssl:
-        client = redis.Redis.from_url(url)
-    else:
+    if is_ssl_connection and not verify_ssl:
         parsed_url = urlparse(url)
         client = redis.Redis(
-            host=parsed_url.hostname,
-            port=parsed_url.port,
-            password=parsed_url.password,
+            host=parsed_url.hostname or "localhost",
+            port=parsed_url.port or 6379,
+            password=parsed_url.password or None,
             ssl=False,
             ssl_cert_reqs="none",
         )
+    else:
+        client = redis.Redis.from_url(url)
     try:
         yield client
     finally:
-        await client.close()
+        await client.aclose()

--- a/sam/utils.py
+++ b/sam/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import enum
 import importlib
 import inspect
@@ -10,12 +11,14 @@ import typing
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
+from urllib.parse import urlparse
 
+import redis.asyncio as redis
 import yaml
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["func_to_tool"]
+__all__ = ["func_to_tool", "async_redis_client"]
 
 
 type_map = {
@@ -128,3 +131,42 @@ class Tool:
 
     def __call__(self, *args, **kwargs):
         return self.fn(*args, **kwargs)
+
+
+@contextlib.asynccontextmanager
+async def async_redis_client(url, verify_ssl=True):
+    """
+    Asynchronous context manager to get a Redis client.
+
+    This function provides a Redis client based on the given URL. If the URL
+    starts with 'rediss://', it is considered a secure connection. The client
+    can be configured to verify SSL certificates.
+
+    Args:
+        url (str): The Redis server URL.
+        verify_ssl (bool): Whether to verify SSL certificates for secure connections.
+                           Defaults to True.
+
+    Yields:
+        redis.Redis: An instance of the Redis client.
+
+    Example:
+        async with async_redis_client("redis://localhost:6379") as client:
+            await client.set("key", "value")
+    """
+    is_ssl_connection = url.startswith("rediss://")
+    if not is_ssl_connection or verify_ssl:
+        client = redis.Redis.from_url(url)
+    else:
+        parsed_url = urlparse(url)
+        client = redis.Redis(
+            host=parsed_url.hostname,
+            port=parsed_url.port,
+            password=parsed_url.password,
+            ssl=False,
+            ssl_cert_reqs="none",
+        )
+    try:
+        yield client
+    finally:
+        await client.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sam import utils
@@ -64,8 +65,15 @@ def test_func_to_tool():
 
 @pytest.mark.asyncio
 async def test_async_redis_client():
-    async with utils.async_redis_client("redis:///") as client:
-        assert await client.ping() is True
+    with patch("redis.asyncio.from_url", AsyncMock()) as from_url:
+        async with utils.async_redis_client("redis:///") as client:
+            assert client
+            from_url.assert_called_once()
+            from_url.assert_called_with("redis:///")
+            from_url.reset_mock()
 
-    async with utils.async_redis_client("rediss:///", False) as client:
-        assert await client.ping() is True
+        async with utils.async_redis_client("rediss:///", "none") as client:
+            assert client
+            from_url.assert_called_once()
+            from_url.assert_called_with("rediss:///", ssl_cert_reqs="none")
+            from_url.reset_mock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,3 +60,12 @@ def test_func_to_tool():
             },
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_async_redis_client():
+    async with utils.async_redis_client("redis:///") as client:
+        assert await client.ping() is True
+
+    async with utils.async_redis_client("rediss:///", False) as client:
+        assert await client.ping() is True


### PR DESCRIPTION
Certain services (like Heroku) do require disabling SSL certificate verification for their `rediss` schema:

They do require disabling the certificate validation - https://devcenter.heroku.com/articles/connecting-heroku-redis

This PR is aiming to adjust the client to be able to accept `REDIS_CERT_REQS` and pass it in such cases.