### PR TITLE
Hotfix -- Stop using deprecated asyncio loop logic

### DIFF
--- a/sam/__main__.py
+++ b/sam/__main__.py
@@ -40,15 +40,9 @@ def run(verbose):
 @run.command()
 def slack():
     """Run the Slack bot demon."""
-    from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
+    from .slack import run_slack
 
-    from .slack import get_app
-
-    loop = asyncio.get_event_loop()
-
-    loop.run_until_complete(
-        AsyncSocketModeHandler(get_app(), config.SLACK_APP_TOKEN).start_async()
-    )
+    asyncio.run(run_slack())
 
 
 @cli.group(chain=True)

--- a/sam/slack.py
+++ b/sam/slack.py
@@ -10,6 +10,7 @@ import urllib.request
 from datetime import datetime
 from typing import Any
 
+from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 from slack_bolt.async_app import AsyncSay
 from slack_sdk import errors
 from slack_sdk.web.async_client import AsyncWebClient
@@ -203,11 +204,16 @@ def get_app():  # pragma: no cover
     return app
 
 
+async def run_slack():
+    handler = AsyncSocketModeHandler(get_app(), config.SLACK_APP_TOKEN)
+    await handler.start_async()
+
+
 def fetch_coworker_contacts(_context=None) -> str:
     """Fetch profile data about your coworkers from Slack.
 
     The profiles include:
-    - first & last name
+    - first a last name
     - email address
     - status
     - pronouns


### PR DESCRIPTION
aiohttp dropped support for the deprecated in Python 3.12 method [`get_event_loop()`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop):
https://github.com/aio-libs/aiohttp/issues/8555


In this PR I am adapting the logic to these changes.